### PR TITLE
Fix -s artist missing bug

### DIFF
--- a/irs/__main__.py
+++ b/irs/__main__.py
@@ -116,6 +116,10 @@ def main():
     elif args.album:
         manager.rip_spotify_list("album")
 
+    elif args.song and not args.artist:
+       parser.error("error: must supply -a/--artist if specifying -s/--song")
+       exit(1)
+
     elif args.song:
         manager.rip_mp3()
 


### PR DESCRIPTION
`irs -s SONG` fails with:
```
Traceback (most recent call last):
  File "/home/andrea/.local/bin/irs", line 11, in <module>
    load_entry_point('irs', 'console_scripts', 'irs')()
  File "/home/andrea/pythonWorkspace/irs/irs/__main__.py", line 120, in main
    manager.rip_mp3()
  File "/home/andrea/pythonWorkspace/irs/irs/manager.py", line 269, in rip_mp3
    audio_code = self.find_mp3(song=song, artist=artist)
  File "/home/andrea/pythonWorkspace/irs/irs/manager.py", line 65, in find_mp3
    print (color(song, ["BOLD", "UNDERLINE"]) + ' by ' + color(artist, ["BOLD", "UNDERLINE"]))
  File "/home/andrea/pythonWorkspace/irs/irs/utils.py", line 58, in color
    return (bc.ENDC + eval(color_string) + text + bc.ENDC)
TypeError: must be str, not NoneType
```
I added an error message if `-s` is called without `-a`